### PR TITLE
[Hotfix] Add missing `/api` to config's api key

### DIFF
--- a/config/devqaly.php
+++ b/config/devqaly.php
@@ -36,7 +36,7 @@ return [
     | for you to add your backend custom URL
     |
     */
-    'api' => env('DEVQALY_API_URL', 'https://api.devqaly.com'),
+    'api' => env('DEVQALY_API_URL', 'https://api.devqaly.com/api'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- added `/api` `api` key