### PR TITLE
Convert `info` to `informational`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "devqaly/devqaly-php": "0.1.1"
+        "devqaly/devqaly-php": "0.1.2-alpha"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Middlewares/DevqalyMiddleware.php
+++ b/src/Middlewares/DevqalyMiddleware.php
@@ -52,8 +52,14 @@ class DevqalyMiddleware
         ?string $requestId
     ): void {
         Event::listen(function (MessageLogged $messageLogged) use ($sessionId, $sessionSecretToken, $client, $requestId) {
+            $level = $messageLogged->level;
+
+            if ($level === 'info') {
+                $level = 'informational';
+            }
+
             $client->createLogEvent($sessionId, $sessionSecretToken, [
-                'level' => $messageLogged->level,
+                'level' => $level,
                 'log' => $messageLogged->message,
                 'requestId' => $requestId,
             ]);


### PR DESCRIPTION
- the backend now requires the log level `info` to be passed as `informational`